### PR TITLE
Data Platform Playbook Repo Change.

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       </div>
       <ul class="nav justify-content-end">
         <li class="nav-item">
-          <a class="nav-link active" aria-current="page" href="https://github.com/LBHackney-IT">Github</a>
+          <a class="nav-link active" aria-current="page" href="https://github.com/LBHackney-IT/lbhackney-it.github.io/">Github</a>
         </li>
       </ul>
     </div>
@@ -65,9 +65,7 @@
           <div class="feature">
             <h2 id="data-platform">Data Platform</h2>
             <ul>
-              <li><a href="https://lbhackney-it.github.io/lbh-hackney-data-platform-docs">Hackney Data Platform Documentation</a></li>
-              <li><a href="https://lbhackney-it.github.io/lbh-hackney-data-platform-docs/playbook">HackIT Data Platform Playbook</a></li>
-              <li><a href="https://lbhackney-it.github.io/lbh-hackney-data-platform-docs/dictionary">Data Dictionary</a></li>
+              <li><a href="http://playbook.hackney.gov.uk/Data-Platform-Playbook/">Data Platform Paybook</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Updated the link to the Github repository to this repository rather than the Hackney organisation page.
Updated the Data Platform Playbook link to reflect the change in the repository name.
Removed the two other links due the structural changes to the Data Platform Playbook site.
TODO: Return the removed links once the additional areas have been recreated.