### PR TITLE
Add Tech Radar link

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,10 +64,10 @@
           <div class="feature">
             <h2 id="Our Ways of working">Our ways of working</h2>
             <ul>
-              <li><a href="https://lbhackney-it.github.io/ways-of-working/">PR Process</a></li>
-              <li><a href="https://lbhackney-it.github.io/ways-of-working/ways_of_working">Planning/Prioritisation</a></li>
-              <li><a href="https://lbhackney-it.github.io/ways-of-working/development_standards/">Development Standards </a></li>
-              <li><a href="#">TBC</a></li>
+              <li><a href="https://playbook.hackney.gov.uk/ways-of-working/">PR Process</a></li>
+              <li><a href="https://playbook.hackney.gov.uk/ways-of-working/ways_of_working">Planning/Prioritisation</a></li>
+              <li><a href="https://playbook.hackney.gov.uk/ways-of-working/development_standards/">Development Standards </a></li>
+              <li><a href="https://playbook.hackney.gov.uk/tech-radar">HackIT Technology Radar</a></li>
               <li><a href="#">TBC</a></li>
             </ul>
           </div>
@@ -80,7 +80,7 @@
               <li><a href="https://design-system.hackney.gov.uk">Design System</a></li>
               <li><a href="#">Accessibility</a></li>
               <li><a href="#">Form-builder</a></li>
-              <li><a href="https://lbhackney-it.github.io/micro-frontends/">Micro front-end</a></li>
+              <li><a href="https://playbook.hackney.gov.uk/micro-frontends/">Micro front-end</a></li>
             </ul>
           </div>
         </div>
@@ -91,7 +91,7 @@
             <ul>
               <li><a href="https://playbook.hackney.gov.uk/API-Playbook/">API Playbook</a></li>
               <li><a href="https://github.com/LBHackney-IT">GitHub</a></li>
-                <li><a href="https://playbook.hackney.gov.uk/api-specifications/index">API Specifications</a></li>
+                <li><a href="https://playbook.hackney.gov.uk/api-specifications">API Specifications</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
- Add Tech Radar Link
- Update some links to go to the [playbook.hackney.gov.uk](https://playbook.hackney.gov.uk/) instead of [lbhackney-it.github.io](https://lbhackney-it.github.io/)