### PR TITLE
chore: removing links to infra playbook as we've moved it into a wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,22 +126,6 @@
 
             <div class="col-sm-4">
               <div class="feature">
-                <h2 id="cloud-engineering">Cloud Engineering</h2>
-                <p>
-                <ul>
-                  <li><a href="Infrastructure-Playbook/">Infrastructure Playbook & Docs</a></li>
-                  <li><a href="https://github.com/LBHackney-IT/infrastructure">Infrastructure Repository</a></li>
-                  <li><a href="https://github.com/LBHackney-IT/infrastructure/actions">Infrastructure Build &
-                      Deployments</a>
-                  </li>
-                  <li>HackIT Backstage (Developer Portal)</li>
-                </ul>
-                </p>
-              </div>
-            </div>
-
-            <div class="col-sm-4">
-              <div class="feature">
                 <h2 id="quality-assurance">Quality Assurance</h2>
                 <p>
                 <ul>


### PR DESCRIPTION
We're removing the links to the infrastructure playbook because we've moved all that content into our Wiki.
The infra playbook GitHub Pages site has been turned off already.