### PR TITLE
Remove tech radar link

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,6 @@
                   <li><a href="ways-of-working/">PR Process</a></li>
                   <li><a href="ways-of-working/ways_of_working/">Planning/Prioritisation</a></li>
                   <li><a href="ways-of-working/development_standards/">Development Standards </a></li>
-                  <li><a href="tech-radar">HackIT Technology Radar</a></li>
                   <li><a href="https://developer-api.hackney.gov.uk/">HackIT Developer Hub</a></li>
                   <li><a href="architecture-pillars/">Architecture Pillars</a></li>
                 </ul>


### PR DESCRIPTION
We're about to decommission the tech radar as it's out of date and not helpful right now, so this change removes the link to it.

We'll reinstate it in future when we have some space to think about it.