### PR TITLE
Explicitly reference main branch in actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,8 @@ name: Deploy to GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches:
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The docs use -branch but that doesn't seem to resolve correctly as we weren't seeing the deployment auto-trigger. This change specifies main explicitly to (hopefully) fix that)