### PR TITLE
🤖 Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" # Location of package manifests
+    schedule:
+    interval: "weekly"
+    day: "monday"
+    time: "08:00"
+    groups:
+      straightforward-dependencies:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
This configuration tells Dependabot to group non-major updates into a single PR each week.

## Why?

We need to keep on top of our dependency updates, but it can be onerous to merge loads of tiny PRs across all our repositories. The hope is that a single weekly PR for minor and patch versions will be straightforward to test & merge, without feeling risky.

### Why not major updates too?

Major updates will each get their own PR, because they're more likely to have breaking changes.

Most of the dependencies are pinned to a major version anyway, so we'll do those manually in most cases.