### PR TITLE
Add Cloud Engineering to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
-# The default owners for are the Hackney development team, and more specialised 
+# The default owners for are the Hackney development team, and more specialised
 # ownership can be added to directories/folders as needed.
 #
-# Note that order matters: more specific rules lower in this file will override 
+# Note that order matters: more specific rules lower in this file will override
 # the default, NOT add to it
 
-*       @LBHackney-IT/development-team
+*       @LBHackney-IT/development-team @LBHackney-IT/cloud-engineering


### PR DESCRIPTION
This site is growing to include ways of working that encompass development and cloud infrastructure, so it's helpful to get their review on PRs and share ownership.

This change adds Cloud Engineering as an owner across all docs. It may make more sense to scope this to just docs/architecture and docs/ways-of-working but I don't know if we care to be that fine grained right now.