### PR TITLE
Enable Google Analytics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -52,8 +52,8 @@ const config = {
         theme: {
           customCss: './src/css/custom.css',
         },
-        googleTagManager: {
-          containerId: 'G-TB9MPCKBPC',
+        gtag: {
+          trackingID: 'G-TB9MPCKBPC',
         },
       }),
     ],


### PR DESCRIPTION
Prior to this change, the Hackney Google Analytics container ID was passed to `docusaurus/plugin-google-analytics`, which _looks_ correct but was deprecated in favour of `docusaurus/plugin-google-tag-manager`. Analytics would have stopped working sometime in 2023.

This change updates our site to use the modern approach. The plugin itself is bundled with the classic theme we're using, so only a configuration change is required.

The `containerId` is shipped to the browser on every page render, so it's not considered a secret.